### PR TITLE
Update NLogLogger.cs

### DIFF
--- a/src/Utility.Logging.NLog/NLogLogger.cs
+++ b/src/Utility.Logging.NLog/NLogLogger.cs
@@ -115,7 +115,7 @@ namespace Utility.Logging.NLog
     protected void Log(global::NLog.LogLevel logLevel, Exception exception, string message, params object[] parameters)
     {
       var logEvent = new global::NLog.LogEventInfo(logLevel, Name, null, message, parameters, exception);
-      logger.Log(logEvent);
+      logger.Log(typeof(NLogLogger), logEvent);
     }
 
     private readonly global::NLog.Logger logger;


### PR DESCRIPTION
Fix wrapper so we can get the original method that caused the logger to log. (${callsite})

See:
http://stackoverflow.com/questions/7412156/how-to-retain-callsite-information-when-wrapping-nlog
http://stackoverflow.com/questions/5132759/nlog-callsite-information
